### PR TITLE
Add Tkinter GUI for agent control

### DIFF
--- a/auto_journalist/README.md
+++ b/auto_journalist/README.md
@@ -94,7 +94,16 @@ This will:
 5. Format and archive a Markdown/HTML newsletter in `output/` and `public/rss/`.
 6. Send personalized messages to Telegram users based on their topics and frequency.
 
-### 6. Automate Daily Runs
+### 6. Launch the Simple GUI
+
+Start the Tkinter-based interface to manually trigger agents:
+
+```bash
+python -m auto_journalist.gui
+```
+
+
+### 7. Automate Daily Runs
 
 #### A) Using Cron
 

--- a/auto_journalist/gui.py
+++ b/auto_journalist/gui.py
@@ -1,0 +1,95 @@
+import asyncio
+import threading
+import tkinter as tk
+from tkinter.scrolledtext import ScrolledText
+
+from .agents.orchestrator_agent import OrchestratorAgent
+from .agents.crawler_agent import CrawlerAgent
+from .agents.summarizer_agent import SummarizerAgent
+from .agents.factcheck_agent import FactCheckAgent
+from .agents.commentary_agent import CommentaryAgent
+from .agents.formatter_agent import FormatterAgent
+from .agents.publisher_agent import PublisherAgent
+
+
+class AgentGUI:
+    def __init__(self, master: tk.Tk) -> None:
+        self.master = master
+        master.title("Auto-Journalist Manager")
+
+        # Log area
+        self.text = ScrolledText(master, width=80, height=20)
+        self.text.pack(fill=tk.BOTH, expand=True)
+
+        # Buttons
+        frame = tk.Frame(master)
+        frame.pack(fill=tk.X)
+        tk.Button(frame, text="Run Daily", command=self.run_daily).pack(side=tk.LEFT)
+        tk.Button(frame, text="Crawler", command=self.run_crawler).pack(side=tk.LEFT)
+        tk.Button(frame, text="Summarizer", command=self.run_summarizer).pack(
+            side=tk.LEFT
+        )
+        tk.Button(frame, text="Fact Check", command=self.run_factcheck).pack(
+            side=tk.LEFT
+        )
+        tk.Button(frame, text="Commentary", command=self.run_commentary).pack(
+            side=tk.LEFT
+        )
+        tk.Button(frame, text="Formatter", command=self.run_formatter).pack(
+            side=tk.LEFT
+        )
+        tk.Button(frame, text="Publish", command=self.run_publisher).pack(side=tk.LEFT)
+
+    def log(self, message: str) -> None:
+        self.text.insert(tk.END, message + "\n")
+        self.text.see(tk.END)
+
+    def run_async(self, coro):
+        def task():
+            self.log(f"Starting {coro.__qualname__}()...")
+            try:
+                asyncio.run(coro())
+                self.log("Done.")
+            except Exception as e:  # pragma: no cover - simple GUI diagnostic
+                self.log(f"Error: {e}")
+
+        threading.Thread(target=task, daemon=True).start()
+
+    # Button callbacks
+    def run_daily(self):
+        orchestrator = OrchestratorAgent()
+        self.run_async(orchestrator.run_daily)
+
+    def run_crawler(self):
+        agent = CrawlerAgent()
+        self.run_async(agent.run)
+
+    def run_summarizer(self):
+        agent = SummarizerAgent()
+        self.run_async(agent.run)
+
+    def run_factcheck(self):
+        agent = FactCheckAgent()
+        self.run_async(agent.run)
+
+    def run_commentary(self):
+        agent = CommentaryAgent()
+        self.run_async(agent.run)
+
+    def run_formatter(self):
+        agent = FormatterAgent()
+        self.run_async(agent.run)
+
+    def run_publisher(self):
+        agent = PublisherAgent()
+        self.run_async(agent.run)
+
+
+def main() -> None:
+    root = tk.Tk()
+    AgentGUI(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple Tkinter GUI to manually run agents
- document how to start the GUI in the README

## Testing
- `black auto_journalist/gui.py`
- `ruff check auto_journalist/gui.py`
- `pytest -q`
- `mypy auto_journalist/gui.py` *(fails: missing stubs)*

------
https://chatgpt.com/codex/tasks/task_e_683f51a9e4748332b439376b9c60342d